### PR TITLE
Removed redundant title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# cfscriptme-command
-
 A CommandBox command for CFML Tag to Script Conversion. This command uses the same engine as [cfscript.me](http://cfscript.me/)
-
 
 ## To Install
 


### PR DESCRIPTION
I've started removing the title from my readme's because it is just redundant and makes the exact same text show up twice on the ForgeBox detail page.